### PR TITLE
name change match ok

### DIFF
--- a/db/migrate/20190219143739_rename_match_column_in_event.rb
+++ b/db/migrate/20190219143739_rename_match_column_in_event.rb
@@ -1,0 +1,5 @@
+class RenameMatchColumnInEvent < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :events, :match, :game
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_19_141527) do
+ActiveRecord::Schema.define(version: 2019_02_19_143739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "events", force: :cascade do |t|
-    t.string "match"
+    t.string "game"
     t.date "date"
     t.text "description"
     t.string "address"


### PR DESCRIPTION
Name change of match column to game column because .match is a function in ruby and therefore it cannot be used as a column name.